### PR TITLE
Filling MC info of lep-nu vertices

### DIFF
--- a/InformationStorages/include/EventInformation.h
+++ b/InformationStorages/include/EventInformation.h
@@ -44,34 +44,26 @@ struct LepNuVertex : public TObject {
 
 ///////////////////// Objects containing several l-nu vertices /////////////////
 
+struct VerticesContainer : public TObject {
+	TObjArray lep_nu_vertices {};
+	LepNuVertex* add_lep_nu_vertex();
 
-struct TJJet : public TObject {
+	VerticesContainer();
+	void Clear( Option_t *option="" );
+
+	ClassDef( VerticesContainer, 1 );
+};
+
+struct TJJet : public VerticesContainer {
 	// Information about one of the jets
 	int fe_pdgID {};
 	TLorentzVector tlv_true {};
 	TLorentzVector tlv_seen {};
-	TObjArray lep_nu_vertices {};
 
 	TJJet();
 
-	LepNuVertex* add_lep_nu_vertex();
-	void Clear( Option_t *option="" );
-
 	ClassDef( TJJet, 1 ); // Make class known to root
 };
-
-struct TotalEvent: public TObject {
-	/* Class to hold non-jet-specific information */
-	TObjArray lep_nu_vertices {};
-
-	TotalEvent();
-
-	LepNuVertex* add_lep_nu_vertex();
-	void Clear( Option_t *option="" );
-
-	ClassDef( TotalEvent, 1 );
-};
-
 
 ///////////////////// All info about this event ////////////////////////////////
 
@@ -79,7 +71,7 @@ struct EventInfo : public TObject {
 	/* General class that holds all information about the event
  	on all the levels of the generation */
 	int evtN{};
-	TotalEvent total_event {};
+	VerticesContainer total_event {};
 	TObjArray tj_jets {};
 
 	EventInfo();

--- a/InformationStorages/include/LinkDef.h
+++ b/InformationStorages/include/LinkDef.h
@@ -13,8 +13,8 @@
 #pragma link C++ class ParticleProperties + ;
 #pragma link C++ class Particle + ;
 #pragma link C++ class LepNuVertex + ;
+#pragma link C++ class VerticesContainer + ;
 #pragma link C++ class TJJet + ;
-#pragma link C++ class TotalEvent + ;
 #pragma link C++ class EventInfo + ;
 
 #endif

--- a/InformationStorages/src/EventInformation.cc
+++ b/InformationStorages/src/EventInformation.cc
@@ -32,37 +32,24 @@ void LepNuVertex::Clear( Option_t *option ){
 	vertex_daughters.Clear(option);
 }
 
+////////////////////////////////// VerticesContainer
+VerticesContainer::VerticesContainer() : TObject() {
+	lep_nu_vertices.SetOwner(kTRUE);
+}
+
+LepNuVertex* VerticesContainer::add_lep_nu_vertex(){
+	LepNuVertex *new_vertex = new LepNuVertex();
+	lep_nu_vertices.Add( new_vertex );
+	return new_vertex;
+}
+
+void VerticesContainer::Clear( Option_t *option ) {
+	lep_nu_vertices.Clear(option);
+}
+
 ////////////////////////////////// TJJet
 
-TJJet::TJJet() : TObject() {
-	lep_nu_vertices.SetOwner(kTRUE);
-}
-
-LepNuVertex* TJJet::add_lep_nu_vertex(){
-	LepNuVertex *new_vertex = new LepNuVertex();
-	lep_nu_vertices.Add( new_vertex );
-	return new_vertex;
-}
-
-void TJJet::Clear( Option_t *option ) {
-  lep_nu_vertices.Clear(option);
-}
-
-////////////////////////////////// TotalEvent
-
-TotalEvent::TotalEvent() : TObject() {
-	lep_nu_vertices.SetOwner(kTRUE);
-}
-
-LepNuVertex* TotalEvent::add_lep_nu_vertex(){
-	LepNuVertex *new_vertex = new LepNuVertex();
-	lep_nu_vertices.Add( new_vertex );
-	return new_vertex;
-}
-
-void TotalEvent::Clear( Option_t *option ) {
-  lep_nu_vertices.Clear(option);
-}
+TJJet::TJJet() : VerticesContainer() {}
 
 ////////////////////////////////// EventInfo
 
@@ -87,7 +74,7 @@ void EventInfo::Clear( Option_t *option ) {
 	ClassImp(ParticleProperties)
 	ClassImp(Particle)
 	ClassImp(LepNuVertex)
+	ClassImp(VerticesContainer)
 	ClassImp(TJJet)
-	ClassImp(TotalEvent)
 	ClassImp(EventInfo)
 #endif

--- a/include/LepNuProcessor.h
+++ b/include/LepNuProcessor.h
@@ -50,10 +50,11 @@ class LepNuProcessor : public Processor , public Adjusted_TrueJet_Parser {
     virtual bool identifiedAsChargedLepton( ReconstructedParticle* PFO );
     virtual void findChargedLeptons( RecoSet &jet_recos_set, RecoSet &jet_leptons_set );
 
+    virtual void fillLepNuVertex( MCParticleVec vertex_parents, MCSet vertex_daughters, LepNuVertex* vertex );
+
     virtual void splitWeight( FloatVec &combined_weights, FloatVec &single_weights, std::string weight_name );
     virtual void findMCLepsToRecoLeps( RecoSet &reco_leps_set, MCSet &mc_leps_set, LCRelationNavigator* relation_recoMCtruth );
-    virtual void findLeptonNeutrinoVertices( RecoSet &jet_leptons_set, LCRelationNavigator* relation_recoMCtruth, EventInfo &info );
-
+    virtual void findLeptonNeutrinoVertices( RecoSet &jet_leptons_set, LCRelationNavigator* relation_recoMCtruth, VerticesContainer* vertices_info );
 
     virtual int findLeptonGeneration( int pdgID );
 

--- a/src/AnalysisTJJets.cc
+++ b/src/AnalysisTJJets.cc
@@ -32,31 +32,7 @@ void LepNuProcessor::analyseTJJets(
 		std::set<ReconstructedParticle*> jet_leptons_set;
 		findChargedLeptons( jet_recos_set, jet_leptons_set );
 
-		findLeptonNeutrinoVertices( jet_leptons_set, relation_recoMCtruth, info );
+		findLeptonNeutrinoVertices( jet_leptons_set, relation_recoMCtruth, jet_info );
 
-		// std::set<MCPMap> mc_lep_nu_pairs;
-		// findLeptonNeutrinoPairs( jet_leptons_set, relation_recoMCtruth, mc_lep_nu_pairs);
-		// streamlog_out(DEBUG) << "Jet " <<  i << ": found " << mc_lep_nu_pairs.size() << " lep-nu pairs." << std::endl;
-		//
-		//
-		// for ( std::set<MCPMap>::iterator lep_nu_pair_it=mc_lep_nu_pairs.begin(); lep_nu_pair_it!=mc_lep_nu_pairs.end(); ++lep_nu_pair_it) {
-		// 	LepNuPair *lep_nu_pair_info = jet_info->add_lep_nu_pair();
-		//
-		// 	MCPMap lep_nu_pair = (*lep_nu_pair_it);
-		//
-		// 	MCParticle* lep = lep_nu_pair.first;
-		// 	std::set<MCParticle*> nus = lep_nu_pair.second;
-		//
-		// 	lep_nu_pair_info->lep_ID = lep->getPDG();
-		// 	lep_nu_pair_info->tlv_lep = TLorentzVector( lep->getMomentum(), lep->getEnergy() );
-		//
-		// 	for ( std::set<MCParticle*>::iterator nu_it=nus.begin(); nu_it!=nus.end(); ++nu_it) {
-		// 		Nu *nu_info = lep_nu_pair_info->add_nu();
-		// 		MCParticle* nu = (*nu_it);
-		//
-		// 		nu_info->nu_ID = nu->getPDG();
-		// 		nu_info->tlv_nu = TLorentzVector( nu->getMomentum(), nu->getEnergy() );
-		// 	}
-		// }
 	}
 }

--- a/src/FillVertex.cpp
+++ b/src/FillVertex.cpp
@@ -1,0 +1,21 @@
+#include "LepNuProcessor.h"
+
+void LepNuProcessor::fillLepNuVertex( MCParticleVec vertex_parents, MCSet vertex_daughters, LepNuVertex* vertex ) {
+  for ( int i=0; i<vertex_parents.size(); i++ ){
+    MCParticle* parent = vertex_parents[i];
+    Particle* parent_info = vertex->add_vertex_parent();
+
+    (parent_info->MC).tlv = TLorentzVector( parent->getMomentum(), parent->getEnergy() );
+    (parent_info->MC).vertex = TVector3( parent->getVertex() );
+    (parent_info->MC).pdg_ID = parent->getPDG();
+  }
+
+  for ( MCSet::iterator daughter_it=vertex_daughters.begin(); daughter_it!=vertex_daughters.end(); ++daughter_it) {
+    MCParticle* daughter = (*daughter_it);
+    Particle* daughter_info = vertex->add_vertex_daughter();
+
+    (daughter_info->MC).tlv = TLorentzVector( daughter->getMomentum(), daughter->getEnergy() );
+    (daughter_info->MC).vertex = TVector3( daughter->getVertex() );
+    (daughter_info->MC).pdg_ID = daughter->getPDG();
+  }
+}

--- a/src/FindLeptonNeutrinoVertices.cc
+++ b/src/FindLeptonNeutrinoVertices.cc
@@ -33,7 +33,7 @@ void LepNuProcessor::findMCLepsToRecoLeps( RecoSet &reco_leps_set, MCSet &mc_lep
 }
 
 
-void LepNuProcessor::findLeptonNeutrinoVertices( RecoSet &reco_leps_set, LCRelationNavigator* relation_recoMCtruth, EventInfo &info ) {
+void LepNuProcessor::findLeptonNeutrinoVertices( RecoSet &reco_leps_set, LCRelationNavigator* relation_recoMCtruth, VerticesContainer* vertices_info ) {
 
   MCSet mc_leps_set;
   findMCLepsToRecoLeps( reco_leps_set, mc_leps_set, relation_recoMCtruth );
@@ -63,8 +63,8 @@ void LepNuProcessor::findLeptonNeutrinoVertices( RecoSet &reco_leps_set, LCRelat
     }
 
     if ( has_nu_sibling ) {
-      //LepNuVertex* new_vertex = 
-      // TODO Fill Vertex here
+      LepNuVertex* new_vertex = vertices_info->add_lep_nu_vertex();
+      fillLepNuVertex( vertex_parents, vertex_daughters, new_vertex );
     }
   }
 }


### PR DESCRIPTION
- Now filling the MC information of the particle in the vertices
containing charged lepton + neutrino daughters.
- Created superclass VerticesContainer everything that hold lep-nu-vertices (e.g. TJ jets).