### PR TITLE
 Correcting rough fit: weights, error estimation, binning

### DIFF
--- a/plotting/plotters/include/plotters.h
+++ b/plotting/plotters/include/plotters.h
@@ -17,6 +17,8 @@ class LepNuPairPlotter : public Plotter {
 	virtual void fill_plots();
 	virtual void draw_plots();
 	virtual bool isNeutrinoID( int pdgID );
+	bool is_Bmeson_ID( int pdgID );
+	bool is_Cmeson_ID( int pdgID );
 	virtual TLorentzVector get_vis_tlv( LepNuVertex* vertex );
 	virtual TLorentzVector get_parents_tlv( LepNuVertex *vertex );
 	virtual TLorentzVector get_charged_lepton_daughters_tlv( LepNuVertex *vertex );

--- a/plotting/plotters/src/cheated_nu_calculation_with_reco_4momenta.cpp
+++ b/plotting/plotters/src/cheated_nu_calculation_with_reco_4momenta.cpp
@@ -254,12 +254,12 @@ void CheatedNuCalculationReco4MomentaPlotter::fill_plots(){
 			TLorentzVector nu_tlv_calculated_minus = calculate_nus( vertex, "minus" );
 			TLorentzVector nu_tlv_calculated_cheated = calculate_nus( vertex, "cheat" );
 
-			get_TH2D("nu_E_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
-			get_TH2D("nu_E_sign_cheated")->Fill(nu_tlv_true.E(), nu_tlv_calculated_cheated.E(), weight);
+			get_TH2D("nu_E_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
+			get_TH2D("nu_E_sign_cheated")->Fill(nu_tlv_true.E(), nu_tlv_calculated_cheated.E(), 1);
 
 			if ( fabs(first_parent_pdg) == 511 || fabs(first_parent_pdg) == 521 || fabs(first_parent_pdg) == 531 ) {
-				get_TH2D("nu_E_Bparents_only_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
-				get_TH2D("nu_E_Bparents_only_sign_cheated")->Fill(nu_tlv_true.E(), nu_tlv_calculated_cheated.E(), weight);
+				get_TH2D("nu_E_Bparents_only_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
+				get_TH2D("nu_E_Bparents_only_sign_cheated")->Fill(nu_tlv_true.E(), nu_tlv_calculated_cheated.E(), 1);
 
 				// std::cout << "B parent case: nu: true: " << nu_tlv_true.E() << " calc: " << nu_tlv_calculated.E() << " Init_vertex position:" << ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag() << " \n\n";
 			}

--- a/plotting/plotters/src/lep_nu_pair_plotter.cpp
+++ b/plotting/plotters/src/lep_nu_pair_plotter.cpp
@@ -151,16 +151,16 @@ void LepNuPairPlotter::fill_plots(){
 			TLorentzVector parents_tlv = get_parents_tlv( vertex );
 			TLorentzVector deboosted_charged_leps_tlv = get_charged_lepton_daughters_tlv( vertex );
 			TLorentzVector deboosted_nus_tlv = get_nu_daughters_tlv( vertex );
-			get_TH2D("lep_nu_E")->Fill(deboosted_charged_leps_tlv.E(), deboosted_nus_tlv.E(), weight);
+			get_TH2D("lep_nu_E")->Fill(deboosted_charged_leps_tlv.E(), deboosted_nus_tlv.E(), 1);
 			deboosted_charged_leps_tlv.Boost(-1.0*parents_tlv.BoostVector());
 			deboosted_nus_tlv.Boost(-1.0*parents_tlv.BoostVector());
 
-			get_TH2D("deboosted_lep_nu_E")->Fill(deboosted_charged_leps_tlv.E(), deboosted_nus_tlv.E(), weight);
-			get_TH2D("deboosted_lep_nu_theta")->Fill(deboosted_charged_leps_tlv.Theta(), deboosted_nus_tlv.Theta(), weight);
-			get_TH2D("deboosted_lep_nu_phi")->Fill(deboosted_charged_leps_tlv.Phi(), deboosted_nus_tlv.Phi(), weight);
+			get_TH2D("deboosted_lep_nu_E")->Fill(deboosted_charged_leps_tlv.E(), deboosted_nus_tlv.E(), 1);
+			get_TH2D("deboosted_lep_nu_theta")->Fill(deboosted_charged_leps_tlv.Theta(), deboosted_nus_tlv.Theta(), 1);
+			get_TH2D("deboosted_lep_nu_phi")->Fill(deboosted_charged_leps_tlv.Phi(), deboosted_nus_tlv.Phi(), 1);
 
-			get_TH1D("deboosted_lep_nu_DeltaR")->Fill(deboosted_nus_tlv.DeltaR(deboosted_charged_leps_tlv), weight);
-			get_TH1D("deboosted_lep_nu_Angle")->Fill(deboosted_nus_tlv.Angle(deboosted_charged_leps_tlv.Vect()), weight);
+			get_TH1D("deboosted_lep_nu_DeltaR")->Fill(deboosted_nus_tlv.DeltaR(deboosted_charged_leps_tlv), 1);
+			get_TH1D("deboosted_lep_nu_Angle")->Fill(deboosted_nus_tlv.Angle(deboosted_charged_leps_tlv.Vect()), 1);
 
 
 
@@ -171,8 +171,8 @@ void LepNuPairPlotter::fill_plots(){
 			TLorentzVector with_vis_deboosted_nus_tlv = get_nu_daughters_tlv( vertex );
 			with_vis_deboosted_nus_tlv.Boost(-1.0*vis_tlv.BoostVector());
 
-			get_TH1D("with_vis_deboosted_lep_nu_DeltaR")->Fill(with_vis_deboosted_nus_tlv.DeltaR(with_vis_deboosted_charged_leps_tlv), weight);
-			get_TH1D("with_vis_deboosted_lep_nu_Angle")->Fill(with_vis_deboosted_nus_tlv.Angle(with_vis_deboosted_charged_leps_tlv.Vect()), weight);
+			get_TH1D("with_vis_deboosted_lep_nu_DeltaR")->Fill(with_vis_deboosted_nus_tlv.DeltaR(with_vis_deboosted_charged_leps_tlv), 1);
+			get_TH1D("with_vis_deboosted_lep_nu_Angle")->Fill(with_vis_deboosted_nus_tlv.Angle(with_vis_deboosted_charged_leps_tlv.Vect()), 1);
 
 			// get_TH1D("deboosted_lep_nu_DeltaR")->Fill(deboosted_nus_tlv.DeltaR(deboosted_charged_leps_tlv), weight);
 

--- a/plotting/plotters/src/lep_nu_pair_plotter.cpp
+++ b/plotting/plotters/src/lep_nu_pair_plotter.cpp
@@ -10,6 +10,10 @@ void LepNuPairPlotter::define_plots(){
 	add_new_TH2D("lep_nu_E",
 		new TH2D(	"lep_nu_E", "lep-#nu-pair energies; E_{l} [GeV]; E_{#nu} [GeV]; Pairs", 20, 0, 100, 20, 0, 100 )
 	);
+
+	add_new_TH2D("lep_nu_E_CandBparents",
+		new TH2D(	"lep_nu_E_CandBparents", "lep-#nu-pair energies, C and B parents; E_{l} [GeV]; E_{#nu} [GeV]; Pairs", 20, 0, 100, 20, 0, 100 )
+	);
 	//
 	// add_new_TH2D("lep_nu_theta",
 	// 	new TH2D(	"lep_nu_theta", "lep-#nu-pair thetas; #theta_{l} [GeV]; #theta_{#nu} [GeV]; Pairs",
@@ -138,6 +142,22 @@ TLorentzVector LepNuPairPlotter::get_nu_daughters_tlv( LepNuVertex *vertex ){
 	return nu_tlv;
 }
 
+bool  LepNuPairPlotter::is_Bmeson_ID( int pdgID ) {
+  if ( fabs(pdgID) == 511 || fabs(pdgID) == 521 || fabs(pdgID) == 531 ){
+      return true;
+  } else {
+    return false;
+  }
+}
+
+bool  LepNuPairPlotter::is_Cmeson_ID( int pdgID ) {
+  if ( fabs(pdgID) == 411 || fabs(pdgID) == 421 || fabs(pdgID) == 431 ){
+      return true;
+  } else {
+    return false;
+  }
+}
+
 void LepNuPairPlotter::fill_plots(){
 	float weight = get_current_weight();
 
@@ -152,6 +172,10 @@ void LepNuPairPlotter::fill_plots(){
 			TLorentzVector deboosted_charged_leps_tlv = get_charged_lepton_daughters_tlv( vertex );
 			TLorentzVector deboosted_nus_tlv = get_nu_daughters_tlv( vertex );
 			get_TH2D("lep_nu_E")->Fill(deboosted_charged_leps_tlv.E(), deboosted_nus_tlv.E(), 1);
+			int first_parent_pdg = ((Particle*)((vertex->vertex_parents)[0]))->MC.pdg_ID;
+			if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
+				get_TH2D("lep_nu_E_CandBparents")->Fill(deboosted_charged_leps_tlv.E(), deboosted_nus_tlv.E(), 1);
+			}
 			deboosted_charged_leps_tlv.Boost(-1.0*parents_tlv.BoostVector());
 			deboosted_nus_tlv.Boost(-1.0*parents_tlv.BoostVector());
 

--- a/plotting/plotters/src/nu_calculation_proof_of_principle.cpp
+++ b/plotting/plotters/src/nu_calculation_proof_of_principle.cpp
@@ -286,198 +286,198 @@ void NuCalculationPOPPlotter::fill_plots(){
 
 			TLorentzVector nu_tlv_calculated_plus = calculate_nus_from_MC( vertex, "plus" );
 			//std::cout << "nu: true: " << nu_tlv_true.E() << " calc: " << nu_tlv_calculated_plus.E() << " Init_vertex position:" << ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag() << " \n\n";
-			get_TH2D("nu_E_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
-			get_TH2D("nu_p_plus")->Fill(nu_tlv_true.P(), nu_tlv_calculated_plus.P(), weight);
-			get_TH2D("nu_theta_plus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_plus.Theta(), weight);
-			get_TH2D("nu_phi_plus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_plus.Phi(), weight);
+			get_TH2D("nu_E_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
+			get_TH2D("nu_p_plus")->Fill(nu_tlv_true.P(), nu_tlv_calculated_plus.P(), 1);
+			get_TH2D("nu_theta_plus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_plus.Theta(), 1);
+			get_TH2D("nu_phi_plus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_plus.Phi(), 1);
 
 			if ( nu_tlv_calculated_plus.E() == 0 ) {
-				get_TH1D("non-reconstructed_nu_parent_init_vertex_plus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), weight);
-				get_TH1D("non-reconstructed_nu_E_plus")->Fill(nu_tlv_true.E(), weight);
-				get_TH1D("non-reconstructed_nu_theta_plus")->Fill(nu_tlv_true.Theta(), weight);
-				get_TH1D("non-reconstructed_nu_phi_plus")->Fill(nu_tlv_true.Phi(), weight);
+				get_TH1D("non-reconstructed_nu_parent_init_vertex_plus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), 1);
+				get_TH1D("non-reconstructed_nu_E_plus")->Fill(nu_tlv_true.E(), 1);
+				get_TH1D("non-reconstructed_nu_theta_plus")->Fill(nu_tlv_true.Theta(), 1);
+				get_TH1D("non-reconstructed_nu_phi_plus")->Fill(nu_tlv_true.Phi(), 1);
 			} else {
-				get_TH1D("reconstructed_nu_parent_init_vertex_plus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), weight);
-				get_TH2D("reconstructed_nu_E_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
-				get_TH2D("reconstructed_nu_theta_plus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_plus.Theta(), weight);
-				get_TH2D("reconstructed_nu_phi_plus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_plus.Phi(), weight);
+				get_TH1D("reconstructed_nu_parent_init_vertex_plus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), 1);
+				get_TH2D("reconstructed_nu_E_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
+				get_TH2D("reconstructed_nu_theta_plus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_plus.Theta(), 1);
+				get_TH2D("reconstructed_nu_phi_plus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_plus.Phi(), 1);
 			}
 
 
 			if ( fabs(first_parent_pdg) == 511 || fabs(first_parent_pdg) == 521 || fabs(first_parent_pdg) == 531 ) {
-				get_TH2D("nu_E_Bparents_only_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+				get_TH2D("nu_E_Bparents_only_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 				float parent_init_pos = ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(); // TODO Adjust to non-zero init vertex
 				if ( parent_init_pos < 1.0 ) {
-					get_TH2D("nu_E_Bparents_only_0vertex_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+					get_TH2D("nu_E_Bparents_only_0vertex_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					if ( vis_vertex_E > 5.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr5_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr5_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( vis_vertex_E > 10.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr10_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr10_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( vis_vertex_E > 15.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr15_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr15_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( vis_vertex_E > 20.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr20_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr20_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( vis_vertex_E > 30.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr30_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr30_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( vis_vertex_E > 50.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr50_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr50_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 
 					float charged_leps_vertex_E = (get_charged_leptons_tlv(vertex)).E();
 					if ( charged_leps_vertex_E > 5.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr5_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
-						get_TH2D("E_deviations_lepE5cut_plus")->Fill((nu_tlv_calculated_plus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr5_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
+						get_TH2D("E_deviations_lepE5cut_plus")->Fill((nu_tlv_calculated_plus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 10.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr10_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr10_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 15.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr15_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr15_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 20.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr20_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr20_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 30.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr30_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr30_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 50.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr50_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr50_plus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_plus.E(), 1);
 					}
-					get_TH2D("E_deviations_plus")->Fill((nu_tlv_calculated_plus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_visE_plus")->Fill(vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_lepE_plus")->Fill(charged_leps_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_lepEpercentage_plus")->Fill(charged_leps_vertex_E/vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_nuTheta_plus")->Fill(nu_tlv_calculated_plus.Theta(), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_correctedE_plus")->Fill( nu_tlv_calculated_plus.E()+vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_plus")->Fill((nu_tlv_calculated_plus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_visE_plus")->Fill(vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_lepE_plus")->Fill(charged_leps_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_lepEpercentage_plus")->Fill(charged_leps_vertex_E/vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_nuTheta_plus")->Fill(nu_tlv_calculated_plus.Theta(), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_correctedE_plus")->Fill( nu_tlv_calculated_plus.E()+vis_vertex_E, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
 
 					int first_lep_pdg = get_first_charged_lepton_pdg(vertex);
-					get_TH2D("E_deviations_lepPDG_plus")->Fill(fabs(first_lep_pdg), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_lepPDG_plus")->Fill(fabs(first_lep_pdg), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
 
 					int N_daughters = (vertex->vertex_daughters).GetEntries();
-					get_TH2D("E_deviations_Ndaughters_plus")->Fill( N_daughters, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_Ndaughters_plus")->Fill( N_daughters, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
 
-					get_TH2D("E_deviations_Bboost_plus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("p_nu_parallel_vs_Bboost_plus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated_plus.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), weight);
+					get_TH2D("E_deviations_Bboost_plus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("p_nu_parallel_vs_Bboost_plus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated_plus.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), 1);
 
-					get_TH1D("B_magnitude_plus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), weight );
-					get_TH2D("B_E_vs_B_magnitude_plus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.E(), weight );
+					get_TH1D("B_magnitude_plus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), 1 );
+					get_TH2D("B_E_vs_B_magnitude_plus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.E(), 1 );
 
-					get_TH2D("E_deviations_Bmagnitude_plus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_Bmagnitude_plus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1);
 
 					{
 						TVector3 init_direction = ((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit();
 						float vis_p_parallel = vis_tlv.Vect().Dot(init_direction);
 						TVector3 perp_to_init = ( vis_tlv.Vect() - vis_p_parallel*init_direction ).Unit();
 						long double vis_p_perp = vis_tlv.Vect().Dot( perp_to_init );
-						get_TH2D("E_deviations_visPperp_plus")->Fill( vis_p_perp, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight );
-						get_TH2D("E_deviations_visPratio_plus")->Fill( vis_p_perp/vis_p_parallel, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), weight );
-						get_TH2D("Bboost_visPratio_plus")->Fill( vis_p_perp/vis_p_parallel, ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), weight );
+						get_TH2D("E_deviations_visPperp_plus")->Fill( vis_p_perp, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1 );
+						get_TH2D("E_deviations_visPratio_plus")->Fill( vis_p_perp/vis_p_parallel, nu_tlv_calculated_plus.E()-nu_tlv_true.E(), 1 );
+						get_TH2D("Bboost_visPratio_plus")->Fill( vis_p_perp/vis_p_parallel, ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), 1 );
 
-						get_TH2D("Bbeta_visPparOVERvisE_plus")->Fill(1.0-vis_p_parallel/vis_vertex_E, 1.0-((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Beta(), weight);
+						get_TH2D("Bbeta_visPparOVERvisE_plus")->Fill(1.0-vis_p_parallel/vis_vertex_E, 1.0-((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Beta(), 1);
 					}
 				}
 			}
 
 			TLorentzVector nu_tlv_calculated_minus = calculate_nus_from_MC( vertex, "minus" );
 			//std::cout << "nu: true: " << nu_tlv_true.E() << " calc: " << nu_tlv_calculated_minus.E() << " Init_vertex position:" << ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag() << " \n\n";
-			get_TH2D("nu_E_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
-			get_TH2D("nu_p_minus")->Fill(nu_tlv_true.P(), nu_tlv_calculated_minus.P(), weight);
-			get_TH2D("nu_theta_minus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_minus.Theta(), weight);
-			get_TH2D("nu_phi_minus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_minus.Phi(), weight);
+			get_TH2D("nu_E_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
+			get_TH2D("nu_p_minus")->Fill(nu_tlv_true.P(), nu_tlv_calculated_minus.P(), 1);
+			get_TH2D("nu_theta_minus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_minus.Theta(), 1);
+			get_TH2D("nu_phi_minus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_minus.Phi(), 1);
 
 			if ( nu_tlv_calculated_minus.E() == 0 ) {
-				get_TH1D("non-reconstructed_nu_parent_init_vertex_minus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), weight);
-				get_TH1D("non-reconstructed_nu_E_minus")->Fill(nu_tlv_true.E(), weight);
-				get_TH1D("non-reconstructed_nu_theta_minus")->Fill(nu_tlv_true.Theta(), weight);
-				get_TH1D("non-reconstructed_nu_phi_minus")->Fill(nu_tlv_true.Phi(), weight);
+				get_TH1D("non-reconstructed_nu_parent_init_vertex_minus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), 1);
+				get_TH1D("non-reconstructed_nu_E_minus")->Fill(nu_tlv_true.E(), 1);
+				get_TH1D("non-reconstructed_nu_theta_minus")->Fill(nu_tlv_true.Theta(), 1);
+				get_TH1D("non-reconstructed_nu_phi_minus")->Fill(nu_tlv_true.Phi(), 1);
 			} else {
-				get_TH1D("reconstructed_nu_parent_init_vertex_minus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), weight);
-				get_TH2D("reconstructed_nu_E_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
-				get_TH2D("reconstructed_nu_theta_minus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_minus.Theta(), weight);
-				get_TH2D("reconstructed_nu_phi_minus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_minus.Phi(), weight);
+				get_TH1D("reconstructed_nu_parent_init_vertex_minus")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), 1);
+				get_TH2D("reconstructed_nu_E_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
+				get_TH2D("reconstructed_nu_theta_minus")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated_minus.Theta(), 1);
+				get_TH2D("reconstructed_nu_phi_minus")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated_minus.Phi(), 1);
 			}
 
 
 			if ( fabs(first_parent_pdg) == 511 || fabs(first_parent_pdg) == 521 || fabs(first_parent_pdg) == 531 ) {
-				get_TH2D("nu_E_Bparents_only_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+				get_TH2D("nu_E_Bparents_only_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 				float parent_init_pos = ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(); // TODO Adjust to non-zero init vertex
 				if ( parent_init_pos < 1.0 ) {
-					get_TH2D("nu_E_Bparents_only_0vertex_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+					get_TH2D("nu_E_Bparents_only_0vertex_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					if ( vis_vertex_E > 5.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr5_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr5_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( vis_vertex_E > 10.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr10_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr10_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( vis_vertex_E > 15.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr15_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr15_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( vis_vertex_E > 20.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr20_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr20_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( vis_vertex_E > 30.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr30_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr30_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( vis_vertex_E > 50.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr50_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr50_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 
 					float charged_leps_vertex_E = (get_charged_leptons_tlv(vertex)).E();
 					if ( charged_leps_vertex_E > 5.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr5_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
-						get_TH2D("E_deviations_lepE5cut_minus")->Fill((nu_tlv_calculated_minus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr5_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
+						get_TH2D("E_deviations_lepE5cut_minus")->Fill((nu_tlv_calculated_minus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 10.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr10_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr10_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 15.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr15_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr15_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 20.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr20_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr20_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 30.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr30_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr30_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 50.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr50_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr50_minus")->Fill(nu_tlv_true.E(), nu_tlv_calculated_minus.E(), 1);
 					}
-					get_TH2D("E_deviations_minus")->Fill((nu_tlv_calculated_minus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_visE_minus")->Fill(vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_lepE_minus")->Fill(charged_leps_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_lepEpercentage_minus")->Fill(charged_leps_vertex_E/vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_nuTheta_minus")->Fill(nu_tlv_calculated_minus.Theta(), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_correctedE_minus")->Fill( nu_tlv_calculated_minus.E()+vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_minus")->Fill((nu_tlv_calculated_minus.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_visE_minus")->Fill(vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_lepE_minus")->Fill(charged_leps_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_lepEpercentage_minus")->Fill(charged_leps_vertex_E/vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_nuTheta_minus")->Fill(nu_tlv_calculated_minus.Theta(), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_correctedE_minus")->Fill( nu_tlv_calculated_minus.E()+vis_vertex_E, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
 
 					int first_lep_pdg = get_first_charged_lepton_pdg(vertex);
-					get_TH2D("E_deviations_lepPDG_minus")->Fill(fabs(first_lep_pdg), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_lepPDG_minus")->Fill(fabs(first_lep_pdg), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
 
 					int N_daughters = (vertex->vertex_daughters).GetEntries();
-					get_TH2D("E_deviations_Ndaughters_minus")->Fill( N_daughters, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_Ndaughters_minus")->Fill( N_daughters, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
 
-					get_TH2D("E_deviations_Bboost_minus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
-					get_TH2D("p_nu_parallel_vs_Bboost_minus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated_minus.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), weight);
+					get_TH2D("E_deviations_Bboost_minus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
+					get_TH2D("p_nu_parallel_vs_Bboost_minus")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated_minus.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), 1);
 
-					get_TH1D("B_magnitude_minus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), weight );
-					get_TH2D("B_E_vs_B_magnitude_minus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.E(), weight );
+					get_TH1D("B_magnitude_minus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), 1 );
+					get_TH2D("B_E_vs_B_magnitude_minus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.E(), 1 );
 
-					get_TH2D("E_deviations_Bmagnitude_minus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_Bmagnitude_minus")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1);
 
 					{
 						TVector3 init_direction = ((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit();
 						float vis_p_parallel = vis_tlv.Vect().Dot(init_direction);
 						TVector3 perp_to_init = ( vis_tlv.Vect() - vis_p_parallel*init_direction ).Unit();
 						long double vis_p_perp = vis_tlv.Vect().Dot( perp_to_init );
-						get_TH2D("E_deviations_visPperp_minus")->Fill( vis_p_perp, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight );
-						get_TH2D("E_deviations_visPratio_minus")->Fill( vis_p_perp/vis_p_parallel, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), weight );
-						get_TH2D("Bboost_visPratio_minus")->Fill( vis_p_perp/vis_p_parallel, ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), weight );
+						get_TH2D("E_deviations_visPperp_minus")->Fill( vis_p_perp, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1 );
+						get_TH2D("E_deviations_visPratio_minus")->Fill( vis_p_perp/vis_p_parallel, nu_tlv_calculated_minus.E()-nu_tlv_true.E(), 1 );
+						get_TH2D("Bboost_visPratio_minus")->Fill( vis_p_perp/vis_p_parallel, ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), 1 );
 
-						get_TH2D("Bbeta_visPparOVERvisE_minus")->Fill(1.0-vis_p_parallel/vis_vertex_E, 1.0-((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Beta(), weight);
+						get_TH2D("Bbeta_visPparOVERvisE_minus")->Fill(1.0-vis_p_parallel/vis_vertex_E, 1.0-((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Beta(), 1);
 					}
 				}
 			}

--- a/plotting/plotters/src/nu_calculation_proof_of_principle_cheated_sign.cpp
+++ b/plotting/plotters/src/nu_calculation_proof_of_principle_cheated_sign.cpp
@@ -195,23 +195,23 @@ TLorentzVector NuCalculationCheatedSignPOPPlotter::calculate_nus_from_MC( LepNuV
 		nu_tlv = right_sign_nu_tlv;
 
 		float weight = get_current_weight();
-		get_TH1D("deboosted_lep_rightsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , weight);
-		get_TH1D("deboosted_lep_wrongsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , weight);
-		get_TH1D("with_vis_deboosted_lep_rightsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , weight);
-		get_TH1D("with_vis_deboosted_lep_wrongsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , weight);
-		get_TH1D("with_calc_deboosted_lep_rightsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+right_sign_nu_tlv) , weight);
-		get_TH1D("with_calc_deboosted_lep_wrongsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+wrong_sign_nu_tlv) , weight);
+		get_TH1D("deboosted_lep_rightsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , 1);
+		get_TH1D("deboosted_lep_wrongsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , 1);
+		get_TH1D("with_vis_deboosted_lep_rightsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , 1);
+		get_TH1D("with_vis_deboosted_lep_wrongsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , 1);
+		get_TH1D("with_calc_deboosted_lep_rightsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+right_sign_nu_tlv) , 1);
+		get_TH1D("with_calc_deboosted_lep_wrongsign_nu_DeltaR")->Fill( get_deboosted_DeltaR(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+wrong_sign_nu_tlv) , 1);
 
-		get_TH1D("deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , weight);
-		get_TH1D("deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , weight);
-		get_TH1D("with_vis_deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , weight);
-		get_TH1D("with_vis_deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , weight);
-		get_TH1D("with_calc_deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+right_sign_nu_tlv) , weight);
-		get_TH1D("with_calc_deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+wrong_sign_nu_tlv) , weight);
+		get_TH1D("deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , 1);
+		get_TH1D("deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), parents_tlv) , 1);
+		get_TH1D("with_vis_deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , 1);
+		get_TH1D("with_vis_deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv) , 1);
+		get_TH1D("with_calc_deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+right_sign_nu_tlv) , 1);
+		get_TH1D("with_calc_deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+wrong_sign_nu_tlv) , 1);
 
 
-		get_TH1D("with_wrongcalc_deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+wrong_sign_nu_tlv) , weight);
-		get_TH1D("with_rightcalc_deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+right_sign_nu_tlv) , weight);
+		get_TH1D("with_wrongcalc_deboosted_lep_rightsign_nu_angle")->Fill( get_deboosted_angle(right_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+wrong_sign_nu_tlv) , 1);
+		get_TH1D("with_rightcalc_deboosted_lep_wrongsign_nu_angle")->Fill( get_deboosted_angle(wrong_sign_nu_tlv, get_charged_lepton_daughters_tlv(vertex), vis_tlv+right_sign_nu_tlv) , 1);
 	}
 
 	return nu_tlv;
@@ -230,14 +230,14 @@ void NuCalculationCheatedSignPOPPlotter::fill_plots(){
 			TLorentzVector nu_tlv_calculated = calculate_nus_from_MC( vertex );
 			TLorentzVector nu_tlv_true = get_nu_daughters_tlv( vertex );
 			//std::cout << "nu: true: " << nu_tlv_true.E() << " calc: " << nu_tlv_calculated.E() << " Init_vertex position:" << ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag() << " \n\n";
-			get_TH2D("nu_E")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+			get_TH2D("nu_E")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 
 			int first_parent_pdg = ((Particle*)((vertex->vertex_parents)[0]))->MC.pdg_ID;
 			if ( fabs(first_parent_pdg) == 511 || fabs(first_parent_pdg) == 521 || fabs(first_parent_pdg) == 531 ) {
 				float parent_init_pos = ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(); // TODO Adjust to non-zero init vertex
 				if ( parent_init_pos < 1.0 ) {
-					get_TH2D("nu_E_Bparents_only_0vertex")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
-					get_TH2D("p_nu_parallel_vs_Bboost")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), weight);
+					get_TH2D("nu_E_Bparents_only_0vertex")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
+					get_TH2D("p_nu_parallel_vs_Bboost")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), 1);
 				}
 			}
 			if ( fabs((nu_tlv_calculated - nu_tlv_true).E()) > 40 ) {

--- a/plotting/plotters/src/nu_calculation_proof_of_principle_guess_gamma.cpp
+++ b/plotting/plotters/src/nu_calculation_proof_of_principle_guess_gamma.cpp
@@ -221,27 +221,27 @@ void NuCalculationPOPGuessedGammaPlotter::fill_plots(){
 	while ( get_next_event() ) {
 		int N_vertices = (evt_info->total_event.lep_nu_vertices).GetEntries();
 		// std::cout << i++ << "\n";
-		get_TH1D("N_vertices")->Fill(N_vertices, weight);
+		get_TH1D("N_vertices")->Fill(N_vertices, 1);
 		for (int i_vertex = 0; i_vertex<N_vertices; i_vertex++ ) {
 			LepNuVertex* vertex = (LepNuVertex*)evt_info->total_event.lep_nu_vertices[i_vertex];
 			TLorentzVector nu_tlv_calculated = calculate_nus_from_MC( vertex );
 			TLorentzVector nu_tlv_true = get_nu_daughters_tlv( vertex );
 			//std::cout << "nu: true: " << nu_tlv_true.E() << " calc: " << nu_tlv_calculated.E() << " Init_vertex position:" << ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag() << " \n\n";
-			get_TH2D("nu_E")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
-			get_TH2D("nu_p")->Fill(nu_tlv_true.P(), nu_tlv_calculated.P(), weight);
-			get_TH2D("nu_theta")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated.Theta(), weight);
-			get_TH2D("nu_phi")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated.Phi(), weight);
+			get_TH2D("nu_E")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
+			get_TH2D("nu_p")->Fill(nu_tlv_true.P(), nu_tlv_calculated.P(), 1);
+			get_TH2D("nu_theta")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated.Theta(), 1);
+			get_TH2D("nu_phi")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated.Phi(), 1);
 
 			if ( nu_tlv_calculated.E() == 0 ) {
-				get_TH1D("non-reconstructed_nu_parent_init_vertex")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), weight);
-				get_TH1D("non-reconstructed_nu_E")->Fill(nu_tlv_true.E(), weight);
-				get_TH1D("non-reconstructed_nu_theta")->Fill(nu_tlv_true.Theta(), weight);
-				get_TH1D("non-reconstructed_nu_phi")->Fill(nu_tlv_true.Phi(), weight);
+				get_TH1D("non-reconstructed_nu_parent_init_vertex")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), 1);
+				get_TH1D("non-reconstructed_nu_E")->Fill(nu_tlv_true.E(), 1);
+				get_TH1D("non-reconstructed_nu_theta")->Fill(nu_tlv_true.Theta(), 1);
+				get_TH1D("non-reconstructed_nu_phi")->Fill(nu_tlv_true.Phi(), 1);
 			} else {
-				get_TH1D("reconstructed_nu_parent_init_vertex")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), weight);
-				get_TH2D("reconstructed_nu_E")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
-				get_TH2D("reconstructed_nu_theta")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated.Theta(), weight);
-				get_TH2D("reconstructed_nu_phi")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated.Phi(), weight);
+				get_TH1D("reconstructed_nu_parent_init_vertex")->Fill(((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(), 1);
+				get_TH2D("reconstructed_nu_E")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
+				get_TH2D("reconstructed_nu_theta")->Fill(nu_tlv_true.Theta(), nu_tlv_calculated.Theta(), 1);
+				get_TH2D("reconstructed_nu_phi")->Fill(nu_tlv_true.Phi(), nu_tlv_calculated.Phi(), 1);
 			}
 
 			TLorentzVector vis_tlv = get_vis_tlv(vertex);
@@ -249,78 +249,78 @@ void NuCalculationPOPGuessedGammaPlotter::fill_plots(){
 
 			int first_parent_pdg = ((Particle*)((vertex->vertex_parents)[0]))->MC.pdg_ID;
 			if ( fabs(first_parent_pdg) == 511 || fabs(first_parent_pdg) == 521 || fabs(first_parent_pdg) == 531 ) {
-				get_TH2D("nu_E_Bparents_only")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+				get_TH2D("nu_E_Bparents_only")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 				float parent_init_pos = ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(); // TODO Adjust to non-zero init vertex
 				if ( parent_init_pos < 1.0 ) {
-					get_TH2D("nu_E_Bparents_only_0vertex")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+					get_TH2D("nu_E_Bparents_only_0vertex")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					if ( vis_vertex_E > 5.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr5")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr5")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( vis_vertex_E > 10.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr10")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr10")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( vis_vertex_E > 15.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr15")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr15")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( vis_vertex_E > 20.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr20")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr20")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( vis_vertex_E > 30.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr30")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr30")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( vis_vertex_E > 50.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_visEgr50")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_visEgr50")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 
 					float charged_leps_vertex_E = (get_charged_leptons_tlv(vertex)).E();
 					if ( charged_leps_vertex_E > 5.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr5")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
-						get_TH2D("E_deviations_lepE5cut")->Fill((nu_tlv_calculated.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr5")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
+						get_TH2D("E_deviations_lepE5cut")->Fill((nu_tlv_calculated.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 10.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr10")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr10")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 15.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr15")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr15")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 20.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr20")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr20")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 30.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr30")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr30")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
 					if ( charged_leps_vertex_E > 50.0) {
-						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr50")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), weight);
+						get_TH2D("nu_E_Bparents_only_0vertex_lepEgr50")->Fill(nu_tlv_true.E(), nu_tlv_calculated.E(), 1);
 					}
-					get_TH2D("E_deviations")->Fill((nu_tlv_calculated.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_visE")->Fill(vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_lepE")->Fill(charged_leps_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_lepEpercentage")->Fill(charged_leps_vertex_E/vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_nuTheta")->Fill(nu_tlv_calculated.Theta(), nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
-					get_TH2D("E_deviations_correctedE")->Fill( nu_tlv_calculated.E()+vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations")->Fill((nu_tlv_calculated.E()-vis_vertex_E)/vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_visE")->Fill(vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_lepE")->Fill(charged_leps_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_lepEpercentage")->Fill(charged_leps_vertex_E/vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_nuTheta")->Fill(nu_tlv_calculated.Theta(), nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
+					get_TH2D("E_deviations_correctedE")->Fill( nu_tlv_calculated.E()+vis_vertex_E, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
 
 					int first_lep_pdg = get_first_charged_lepton_pdg(vertex);
-					get_TH2D("E_deviations_lepPDG")->Fill(fabs(first_lep_pdg), nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_lepPDG")->Fill(fabs(first_lep_pdg), nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
 
 					int N_daughters = (vertex->vertex_daughters).GetEntries();
-					get_TH2D("E_deviations_Ndaughters")->Fill( N_daughters, nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_Ndaughters")->Fill( N_daughters, nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
 
-					get_TH2D("E_deviations_Bboost")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
-					get_TH2D("p_nu_parallel_vs_Bboost")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), weight);
+					get_TH2D("E_deviations_Bboost")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
+					get_TH2D("p_nu_parallel_vs_Bboost")->Fill( ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), (nu_tlv_calculated.Vect()).Dot(((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit()), 1);
 
-					get_TH1D("B_magnitude")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), weight );
-					get_TH2D("B_E_vs_B_magnitude")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.E(), weight );
+					get_TH1D("B_magnitude")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), 1 );
+					get_TH2D("B_E_vs_B_magnitude")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.E(), 1 );
 
-					get_TH2D("E_deviations_Bmagnitude")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), nu_tlv_calculated.E()-nu_tlv_true.E(), weight);
+					get_TH2D("E_deviations_Bmagnitude")->Fill( ((Particle*)((vertex->vertex_daughters)[0]))->MC.vertex.Mag(), nu_tlv_calculated.E()-nu_tlv_true.E(), 1);
 
 					{
 						TVector3 init_direction = ((Particle*)(vertex->vertex_daughters[0]))->MC.vertex.Unit();
 						float vis_p_parallel = vis_tlv.Vect().Dot(init_direction);
 						TVector3 perp_to_init = ( vis_tlv.Vect() - vis_p_parallel*init_direction ).Unit();
 						long double vis_p_perp = vis_tlv.Vect().Dot( perp_to_init );
-						get_TH2D("E_deviations_visPperp")->Fill( vis_p_perp, nu_tlv_calculated.E()-nu_tlv_true.E(), weight );
-						get_TH2D("E_deviations_visPratio")->Fill( vis_p_perp/vis_p_parallel, nu_tlv_calculated.E()-nu_tlv_true.E(), weight );
-						get_TH2D("Bboost_visPratio")->Fill( vis_p_perp/vis_p_parallel, ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), weight );
+						get_TH2D("E_deviations_visPperp")->Fill( vis_p_perp, nu_tlv_calculated.E()-nu_tlv_true.E(), 1 );
+						get_TH2D("E_deviations_visPratio")->Fill( vis_p_perp/vis_p_parallel, nu_tlv_calculated.E()-nu_tlv_true.E(), 1 );
+						get_TH2D("Bboost_visPratio")->Fill( vis_p_perp/vis_p_parallel, ((Particle*)((vertex->vertex_parents)[0]))->MC.tlv.Gamma(), 1 );
 					}
 				}
 			}

--- a/plotting/plotters/src/nu_rough_correction_fit.cpp
+++ b/plotting/plotters/src/nu_rough_correction_fit.cpp
@@ -8,30 +8,33 @@ void RoughNuCorrectionFitPlotter::set_plotter_settings() {
 
 void RoughNuCorrectionFitPlotter::define_plots(){
 
+	const int N_profile_bins = 12;
+	double profile_binning[N_profile_bins+1] = {0, 1, 2, 3, 5, 7, 10, 15, 20, 30, 50, 70, 100};
+
 	add_new_TH1D("x_parameter_all", new TH1D("x_parameter_all", "x parameter distribution, all parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Cparents", new TH1D("x_parameter_Cparents", "x parameter distribution, C parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Bparents", new TH1D("x_parameter_Bparents", "x parameter distribution, B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_CandBparents", new TH1D("x_parameter_CandBparents", "x parameter distribution, C and B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
-	add_new_TProfile("x_parameter_VS_Elep_CandBparents", new TProfile("x_parameter_VS_Elep_CandBparents", "x parameter : E_{lep} (Profile), C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", 7, 0, 140));
+	add_new_TProfile("x_parameter_VS_Elep_CandBparents", new TProfile("x_parameter_VS_Elep_CandBparents", "x parameter : E_{lep} (Profile), C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", N_profile_bins, profile_binning));
 
 
 	add_new_TH1D("x_parameter_all_Elepmin1", new TH1D("x_parameter_all_Elepmin1", "x parameter distribution, E_{lep} > 1GeV, all parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Cparents_Elepmin1", new TH1D("x_parameter_Cparents_Elepmin1", "x parameter distribution, E_{lep} > 1GeV, C parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Bparents_Elepmin1", new TH1D("x_parameter_Bparents_Elepmin1", "x parameter distribution, E_{lep} > 1GeV, B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_CandBparents_Elepmin1", new TH1D("x_parameter_CandBparents_Elepmin1", "x parameter distribution, E_{lep} > 1GeV, C and B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
-	add_new_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin1", new TProfile("x_parameter_VS_Elep_CandBparents_Elepmin1", "x parameter : E_{lep} (Profile), E_{lep} > 1GeV, C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", 25, 0, 100));
+	add_new_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin1", new TProfile("x_parameter_VS_Elep_CandBparents_Elepmin1", "x parameter : E_{lep} (Profile), E_{lep} > 1GeV, C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", N_profile_bins, profile_binning));
 
 	add_new_TH1D("x_parameter_all_Elepmin3", new TH1D("x_parameter_all_Elepmin3", "x parameter distribution, E_{lep} > 3GeV, all parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Cparents_Elepmin3", new TH1D("x_parameter_Cparents_Elepmin3", "x parameter distribution, E_{lep} > 3GeV, C parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Bparents_Elepmin3", new TH1D("x_parameter_Bparents_Elepmin3", "x parameter distribution, E_{lep} > 3GeV, B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_CandBparents_Elepmin3", new TH1D("x_parameter_CandBparents_Elepmin3", "x parameter distribution, E_{lep} > 3GeV, C and B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
-	add_new_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin3", new TProfile("x_parameter_VS_Elep_CandBparents_Elepmin3", "x parameter : E_{lep} (Profile), E_{lep} > 3GeV, C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", 25, 0, 100));
+	add_new_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin3", new TProfile("x_parameter_VS_Elep_CandBparents_Elepmin3", "x parameter : E_{lep} (Profile), E_{lep} > 3GeV, C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", N_profile_bins, profile_binning));
 
 	add_new_TH1D("x_parameter_all_Elepmin5", new TH1D("x_parameter_all_Elepmin5", "x parameter distribution, E_{lep} > 5GeV, all parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Cparents_Elepmin5", new TH1D("x_parameter_Cparents_Elepmin5", "x parameter distribution, E_{lep} > 5GeV, C parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_Bparents_Elepmin5", new TH1D("x_parameter_Bparents_Elepmin5", "x parameter distribution, E_{lep} > 5GeV, B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
 	add_new_TH1D("x_parameter_CandBparents_Elepmin5", new TH1D("x_parameter_CandBparents_Elepmin5", "x parameter distribution, E_{lep} > 5GeV, C and B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 20, 0, 1.001));
-	add_new_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin5", new TProfile("x_parameter_VS_Elep_CandBparents_Elepmin5", "x parameter : E_{lep} (Profile), E_{lep} > 5GeV, C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", 25, 0, 100));
+	add_new_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin5", new TProfile("x_parameter_VS_Elep_CandBparents_Elepmin5", "x parameter : E_{lep} (Profile), E_{lep} > 5GeV, C and B parents; E_{lep}; < ( E_{lep}/(E_{lep} + E_{#nu}) ) >", N_profile_bins, profile_binning));
 
 
 	add_new_TH1D("x_parameter_CandBparents_Elep0to20", new TH1D("x_parameter_CandBparents_Elepmin0to20", "x parameter distribution, E_{lep} #in (0,20)GeV, C and B parents; E_{lep}/(E_{lep} + E_{#nu}); vertices", 5, 0, 1.001));
@@ -209,6 +212,7 @@ void RoughNuCorrectionFitPlotter::fill_plots(){
 }
 
 void RoughNuCorrectionFitPlotter::get_resolution_projection ( TProfile* plot, TH1D* error_clone ){
+	plot->SetErrorOption("s");
 	for (int i=1; i<plot->GetNbinsX()+2; i++) {
 		if (plot->GetBinContent(i) != 0){
 			error_clone->SetBinContent( i, plot->GetBinError(i) );
@@ -225,7 +229,7 @@ void RoughNuCorrectionFitPlotter::draw_plots(){
 
 	TH1D *x_resolution_VS_Elep_CandBparents = (TH1D*)(get_TProfile("x_parameter_VS_Elep_CandBparents"))->ProjectionX("x_resolution_projection_VS_Elep_CandBparents");
 	get_resolution_projection(get_TProfile("x_parameter_VS_Elep_CandBparents"), x_resolution_VS_Elep_CandBparents);
-	x_resolution_VS_Elep_CandBparents->SetTitle("x resolution : E_{lep} (Profile), C and B parents; E_{lep}; #Delta <x>");
+	x_resolution_VS_Elep_CandBparents->SetTitle("x resolution : E_{lep} (Profile), C and B parents; E_{lep}; #Delta x");
 	add_new_TH1D("x_resolution_VS_Elep_CandBparents", x_resolution_VS_Elep_CandBparents);
 
 
@@ -234,6 +238,7 @@ void RoughNuCorrectionFitPlotter::draw_plots(){
 	get_TH1D("x_parameter_CandBparents")->SetLineColor(9101);
 	get_TH1D("x_parameter_CandBparents")->SetMarkerColor(9101);
 	get_TH1D("x_parameter_CandBparents")->SetMarkerSize(2);
+	get_TH1D("x_parameter_CandBparents")->SetMinimum(0);
 	get_TH1D("x_parameter_CandBparents")->Draw();
 	leg_x->AddEntry(get_TH1D("x_parameter_CandBparents"), "E_{lep,min} = 0");
 	get_TH1D("x_parameter_CandBparents_Elepmin1")->SetLineColor(9102);
@@ -255,26 +260,31 @@ void RoughNuCorrectionFitPlotter::draw_plots(){
 	c_x->Print((output_dir + "/x_distributions.pdf").c_str());
 
 	TCanvas* c_x_0to20 = new TCanvas("c_x_0to20", "", 0, 0, 800, 800);
+	get_TH1D("x_parameter_CandBparents_Elep0to20")->SetMinimum(0);
 	get_TH1D("x_parameter_CandBparents_Elep0to20")->Draw();
 	c_x_0to20->SetTopMargin(0.1);
 	c_x_0to20->Print((output_dir + "/x_distribution_Elep0to20.pdf").c_str());
 
 	TCanvas* c_x_20to40 = new TCanvas("c_x_20to40", "", 0, 0, 800, 800);
+	get_TH1D("x_parameter_CandBparents_Elep20to40")->SetMinimum(0);
 	get_TH1D("x_parameter_CandBparents_Elep20to40")->Draw();
 	c_x_20to40->SetTopMargin(0.1);
 	c_x_20to40->Print((output_dir + "/x_distribution_Elep20to40.pdf").c_str());
 
 	TCanvas* c_x_40to60 = new TCanvas("c_x_40to60", "", 0, 0, 800, 800);
+	get_TH1D("x_parameter_CandBparents_Elep40to60")->SetMinimum(0);
 	get_TH1D("x_parameter_CandBparents_Elep40to60")->Draw();
 	c_x_40to60->SetTopMargin(0.1);
 	c_x_40to60->Print((output_dir + "/x_distribution_Elep40to60.pdf").c_str());
 
 	TCanvas* c_x_60to80 = new TCanvas("c_x_60to80", "", 0, 0, 800, 800);
+	get_TH1D("x_parameter_CandBparents_Elep60to80")->SetMinimum(0);
 	get_TH1D("x_parameter_CandBparents_Elep60to80")->Draw();
 	c_x_60to80->SetTopMargin(0.1);
 	c_x_60to80->Print((output_dir + "/x_distribution_Elep60to80.pdf").c_str());
 
 	TCanvas* c_x_80to100 = new TCanvas("c_x_80to100", "", 0, 0, 800, 800);
+	get_TH1D("x_parameter_CandBparents_Elep80to100")->SetMinimum(0);
 	get_TH1D("x_parameter_CandBparents_Elep80to100")->Draw();
 	c_x_80to100->SetTopMargin(0.1);
 	c_x_80to100->Print((output_dir + "/x_distribution_Elep80to100.pdf").c_str());
@@ -294,11 +304,13 @@ void RoughNuCorrectionFitPlotter::draw_plots(){
 
 	TF1 *fit_dx = new TF1("fit_dx", " [0]+[1]*x ", 0, 100 );
 	TCanvas* c_dx = new TCanvas("c_dx_profile", "", 0, 0, 800, 800);
-	TLegend* leg_dx = new TLegend(0.5, 0.3, 0.87, 0.5);
+	TLegend* leg_dx = new TLegend(0.5, 0.65, 0.87, 0.85);
 	x_resolution_VS_Elep_CandBparents->Draw();
 	x_resolution_VS_Elep_CandBparents->Fit("fit_dx");
 	leg_dx->AddEntry(fit_x, "a + b E_{lep}", "l");
 	leg_dx->Draw();
+	c_dx->SetLeftMargin(0.18);
+	x_resolution_VS_Elep_CandBparents->GetYaxis()->SetTitleOffset(1.3);
 	c_dx->SetTopMargin(0.1);
 	c_dx->Print((output_dir + "/dx_distribution.pdf").c_str());
 

--- a/plotting/plotters/src/nu_rough_correction_fit.cpp
+++ b/plotting/plotters/src/nu_rough_correction_fit.cpp
@@ -128,79 +128,79 @@ void RoughNuCorrectionFitPlotter::fill_plots(){
 
 			int first_parent_pdg = ((Particle*)((vertex->vertex_parents)[0]))->MC.pdg_ID;
 
-			get_TH1D("x_parameter_all")->Fill(x, weight);
+			get_TH1D("x_parameter_all")->Fill(x, 1);
 			if ( is_Cmeson_ID(first_parent_pdg) ) {
-				get_TH1D("x_parameter_Cparents")->Fill(x, weight);
+				get_TH1D("x_parameter_Cparents")->Fill(x, 1);
 			}
 			else if ( is_Bmeson_ID(first_parent_pdg) ) {
-				get_TH1D("x_parameter_Bparents")->Fill(x, weight);
+				get_TH1D("x_parameter_Bparents")->Fill(x, 1);
 			}
 
 			if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
-				get_TH1D("x_parameter_CandBparents")->Fill(x, weight);
-				get_TProfile("x_parameter_VS_Elep_CandBparents")->Fill(charged_leps_tlv.E(), x, weight);
+				get_TH1D("x_parameter_CandBparents")->Fill(x, 1);
+				get_TProfile("x_parameter_VS_Elep_CandBparents")->Fill(charged_leps_tlv.E(), x, 1);
 			}
 
 			if ( charged_leps_tlv.E() > 1 ) {
-				get_TH1D("x_parameter_all_Elepmin1")->Fill(x, weight);
+				get_TH1D("x_parameter_all_Elepmin1")->Fill(x, 1);
 				if ( is_Cmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_Cparents_Elepmin1")->Fill(x, weight);
+					get_TH1D("x_parameter_Cparents_Elepmin1")->Fill(x, 1);
 				}
 				else if ( is_Bmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_Bparents_Elepmin1")->Fill(x, weight);
+					get_TH1D("x_parameter_Bparents_Elepmin1")->Fill(x, 1);
 				}
 
 				if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_CandBparents_Elepmin1")->Fill(x, weight);
-					get_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin1")->Fill(charged_leps_tlv.E(), x, weight);
+					get_TH1D("x_parameter_CandBparents_Elepmin1")->Fill(x, 1);
+					get_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin1")->Fill(charged_leps_tlv.E(), x, 1);
 				}
 			}
 
 			if ( charged_leps_tlv.E() > 3 ) {
-				get_TH1D("x_parameter_all_Elepmin3")->Fill(x, weight);
+				get_TH1D("x_parameter_all_Elepmin3")->Fill(x, 1);
 				if ( is_Cmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_Cparents_Elepmin3")->Fill(x, weight);
+					get_TH1D("x_parameter_Cparents_Elepmin3")->Fill(x, 1);
 				}
 				else if ( is_Bmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_Bparents_Elepmin3")->Fill(x, weight);
+					get_TH1D("x_parameter_Bparents_Elepmin3")->Fill(x, 1);
 				}
 
 				if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_CandBparents_Elepmin3")->Fill(x, weight);
-					get_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin3")->Fill(charged_leps_tlv.E(), x, weight);
+					get_TH1D("x_parameter_CandBparents_Elepmin3")->Fill(x, 1);
+					get_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin3")->Fill(charged_leps_tlv.E(), x, 1);
 				}
 			}
 
 			if ( charged_leps_tlv.E() > 5 ) {
-				get_TH1D("x_parameter_all_Elepmin5")->Fill(x, weight);
+				get_TH1D("x_parameter_all_Elepmin5")->Fill(x, 1);
 				if ( is_Cmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_Cparents_Elepmin5")->Fill(x, weight);
+					get_TH1D("x_parameter_Cparents_Elepmin5")->Fill(x, 1);
 				}
 				else if ( is_Bmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_Bparents_Elepmin5")->Fill(x, weight);
+					get_TH1D("x_parameter_Bparents_Elepmin5")->Fill(x, 1);
 				}
 
 				if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
-					get_TH1D("x_parameter_CandBparents_Elepmin5")->Fill(x, weight);
-					get_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin5")->Fill(charged_leps_tlv.E(), x, weight);
+					get_TH1D("x_parameter_CandBparents_Elepmin5")->Fill(x, 1);
+					get_TProfile("x_parameter_VS_Elep_CandBparents_Elepmin5")->Fill(charged_leps_tlv.E(), x, 1);
 				}
 			}
 
 			if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
 				if ( charged_leps_tlv.E() > 0 && charged_leps_tlv.E() < 20) {
-					get_TH1D("x_parameter_CandBparents_Elep0to20")->Fill(x, weight);
+					get_TH1D("x_parameter_CandBparents_Elep0to20")->Fill(x, 1);
 				}
 				if ( charged_leps_tlv.E() > 20 && charged_leps_tlv.E() < 40) {
-					get_TH1D("x_parameter_CandBparents_Elep20to40")->Fill(x, weight);
+					get_TH1D("x_parameter_CandBparents_Elep20to40")->Fill(x, 1);
 				}
 				if ( charged_leps_tlv.E() > 40 && charged_leps_tlv.E() < 60) {
-					get_TH1D("x_parameter_CandBparents_Elep40to60")->Fill(x, weight);
+					get_TH1D("x_parameter_CandBparents_Elep40to60")->Fill(x, 1);
 				}
 				if ( charged_leps_tlv.E() > 60 && charged_leps_tlv.E() < 80) {
-					get_TH1D("x_parameter_CandBparents_Elep60to80")->Fill(x, weight);
+					get_TH1D("x_parameter_CandBparents_Elep60to80")->Fill(x, 1);
 				}
 				if ( charged_leps_tlv.E() > 80 && charged_leps_tlv.E() < 100) {
-					get_TH1D("x_parameter_CandBparents_Elep80to100")->Fill(x, weight);
+					get_TH1D("x_parameter_CandBparents_Elep80to100")->Fill(x, 1);
 				}
 			}
 

--- a/plotting/plotters/src/nu_rough_correction_on_TJjets.cpp
+++ b/plotting/plotters/src/nu_rough_correction_on_TJjets.cpp
@@ -93,14 +93,14 @@ bool  RoughNuCorrectionOnTJjetsPlotter::is_Cmeson_ID( int pdgID ) {
 }
 
 double RoughNuCorrectionOnTJjetsPlotter::fitted_mean_x( double E_lep ){
-	double a = 0.88;
-	double b = 10.6;
+	double a = 0.72;
+	double b = 1.9;
 	return a*E_lep / ( b + E_lep );
 }
 
 double RoughNuCorrectionOnTJjetsPlotter::fitted_delta_mean_x( double E_lep ){
-	double a = 0.017;
-	double b = 0.00057;
+	double a = 0.243;
+	double b = -0.00105;
 	return a + b*E_lep;
 }
 
@@ -190,66 +190,6 @@ void RoughNuCorrectionOnTJjetsPlotter::fill_plots(){
 void RoughNuCorrectionOnTJjetsPlotter::draw_plots(){
 	std::string output_dir = get_output_directory();
 
-	TCanvas* c_jetE = new TCanvas("c_jetE", "", 0, 0, 800, 800);
-	TLegend* leg_jetE = new TLegend(0.25, 0.7, 0.55, 0.85);
-	get_TProfile("TJjet_meanEseencorrected_vs_Etrue")->SetLineColor(9101);
-	get_TProfile("TJjet_meanEseen_vs_Etrue")->SetLineColor(9102);
-	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue")->SetLineColor(9103);
-	get_TProfile("TJjet_meanEseencorrected_vs_Etrue")->Draw();
-	get_TProfile("TJjet_meanEseen_vs_Etrue")->Draw("same");
-	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue")->Draw("same");
-	leg_jetE->AddEntry(get_TProfile("TJjet_meanEseen_vs_Etrue"), "uncorrected", "l");
-	leg_jetE->AddEntry(get_TProfile("TJjet_meanEseencorrected_vs_Etrue"), "corrected", "l");
-	leg_jetE->AddEntry(get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue"), "with MC #nu", "l");
-	leg_jetE->Draw();
-	gPad->Update();
-	TLine* profile_line = new TLine(0, 0, gPad->GetFrame()->GetY2(), gPad->GetFrame()->GetY2());
-	profile_line->SetLineWidth(1);
-	profile_line->Draw("same");
-	c_jetE->SetTopMargin(0.1);
-	c_jetE->Print((output_dir + "/jetEreco_comparison.pdf").c_str());
-
-
-	TCanvas* c_jetE_bjets = new TCanvas("c_jetE_bjets", "", 0, 0, 800, 800);
-	TLegend* leg_jetE_bjets = new TLegend(0.25, 0.7, 0.55, 0.85);
-	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets")->SetLineColor(9101);
-	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->SetLineColor(9102);
-	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets")->SetLineColor(9103);
-	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->SetMinimum(0);
-	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->Draw();
-	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets")->Draw("same");
-	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets")->Draw("same");
-	leg_jetE_bjets->AddEntry(get_TProfile("TJjet_meanEseen_vs_Etrue_bjets"), "uncorrected", "l");
-	leg_jetE_bjets->AddEntry(get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets"), "corrected", "l");
-	leg_jetE_bjets->AddEntry(get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets"), "with MC #nu", "l");
-	leg_jetE_bjets->Draw();
-	gPad->Update();
-	TLine* profile_line_bjets = new TLine(0, 0, gPad->GetFrame()->GetY2(), gPad->GetFrame()->GetY2());
-	profile_line_bjets->SetLineWidth(1);
-	profile_line_bjets->Draw("same");
-	c_jetE_bjets->SetTopMargin(0.1);
-	c_jetE_bjets->Print((output_dir + "/jetEreco_comparison_bjets.pdf").c_str());
-
-
-	TCanvas* c_jetEpull_bjets = new TCanvas("c_jetEpull_bjets", "", 0, 0, 800, 800);
-	TLegend* leg_jetEpull_bjets = new TLegend(0.25, 0.3, 0.5, 0.45);
-	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets")->SetLineColor(9101);
-	get_TProfile("TJjet_pullEseen_vs_Etrue_bjets")->SetLineColor(9102);
-	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets")->SetLineColor(9103);
-	get_TProfile("TJjet_pullEseen_vs_Etrue_bjets")->Draw();
-	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets")->Draw("same");
-	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets")->Draw("same");
-	leg_jetEpull_bjets->AddEntry(get_TProfile("TJjet_pullEseen_vs_Etrue_bjets"), "uncorrected", "l");
-	leg_jetEpull_bjets->AddEntry(get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets"), "corrected", "l");
-	leg_jetEpull_bjets->AddEntry(get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets"), "with MC #nu", "l");
-	leg_jetEpull_bjets->Draw();
-	gPad->Update();
-	TLine* pull_line_bjets = new TLine(0, 0, gPad->GetFrame()->GetX2(), 0);
-	pull_line_bjets->SetLineWidth(1);
-	pull_line_bjets->Draw("same");
-	c_jetEpull_bjets->SetTopMargin(0.1);
-	c_jetEpull_bjets->Print((output_dir + "/jetEpull_comparison_bjets.pdf").c_str());
-
 	TCanvas* c_jetE_bjets_distr = new TCanvas("c_jetE_bjets_distr", "", 0, 0, 800, 800);
 	TLegend* leg_jetE_bjets_distr = new TLegend(0.55, 0.65, 0.8, 0.85);
 	get_TH1D("TJjet_Etrue_bjets")->SetLineColor(9101);
@@ -270,18 +210,105 @@ void RoughNuCorrectionOnTJjetsPlotter::draw_plots(){
 
 
 
+
+	TCanvas* c_jetE = new TCanvas("c_jetE", "", 0, 0, 800, 800);
+	TLegend* leg_jetE = new TLegend(0.2, 0.62, 0.55, 0.85);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue")->SetLineColor(9101);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue")->SetMarkerColor(9101);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue")->SetMarkerSize(2);
+	get_TProfile("TJjet_meanEseen_vs_Etrue")->SetLineColor(9102);
+	get_TProfile("TJjet_meanEseen_vs_Etrue")->SetMarkerColor(9102);
+	get_TProfile("TJjet_meanEseen_vs_Etrue")->SetMarkerSize(2);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue")->SetLineColor(9103);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue")->SetMarkerColor(9103);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue")->SetMarkerSize(2);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue")->Draw();
+	get_TProfile("TJjet_meanEseen_vs_Etrue")->Draw("same");
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue")->Draw("same");
+	leg_jetE->AddEntry(get_TProfile("TJjet_meanEseen_vs_Etrue"), "uncorrected");
+	leg_jetE->AddEntry(get_TProfile("TJjet_meanEseencorrected_vs_Etrue"), "corrected");
+	leg_jetE->AddEntry(get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue"), "with MC #nu");
+	leg_jetE->Draw();
+	gPad->Update();
+	TLine* profile_line = new TLine(0, 0, gPad->GetFrame()->GetY2(), gPad->GetFrame()->GetY2());
+	profile_line->SetLineWidth(1);
+	profile_line->Draw("same");
+	c_jetE->SetTopMargin(0.1);
+	c_jetE->Print((output_dir + "/jetEreco_comparison.pdf").c_str());
+
+
+	TCanvas* c_jetE_bjets = new TCanvas("c_jetE_bjets", "", 0, 0, 800, 800);
+	TLegend* leg_jetE_bjets = new TLegend(0.2, 0.62, 0.55, 0.85);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets")->SetLineColor(9101);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets")->SetMarkerColor(9101);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets")->SetMarkerSize(2);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->SetLineColor(9102);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->SetMarkerColor(9102);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->SetMarkerSize(2);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets")->SetLineColor(9103);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets")->SetMarkerColor(9103);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets")->SetMarkerSize(2);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->SetMinimum(0);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_bjets")->Draw();
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets")->Draw("same");
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets")->Draw("same");
+	leg_jetE_bjets->AddEntry(get_TProfile("TJjet_meanEseen_vs_Etrue_bjets"), "uncorrected");
+	leg_jetE_bjets->AddEntry(get_TProfile("TJjet_meanEseencorrected_vs_Etrue_bjets"), "corrected");
+	leg_jetE_bjets->AddEntry(get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_bjets"), "with MC #nu");
+	leg_jetE_bjets->Draw();
+	gPad->Update();
+	TLine* profile_line_bjets = new TLine(0, 0, gPad->GetFrame()->GetY2(), gPad->GetFrame()->GetY2());
+	profile_line_bjets->SetLineWidth(1);
+	profile_line_bjets->Draw("same");
+	c_jetE_bjets->SetTopMargin(0.1);
+	c_jetE_bjets->Print((output_dir + "/jetEreco_comparison_bjets.pdf").c_str());
+
+
+	TCanvas* c_jetEpull_bjets = new TCanvas("c_jetEpull_bjets", "", 0, 0, 800, 800);
+	TLegend* leg_jetEpull_bjets = new TLegend(0.2, 0.2, 0.5, 0.45);
+	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets")->SetLineColor(9101);
+	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets")->SetMarkerColor(9101);
+	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets")->SetMarkerSize(2);
+	get_TProfile("TJjet_pullEseen_vs_Etrue_bjets")->SetLineColor(9102);
+	get_TProfile("TJjet_pullEseen_vs_Etrue_bjets")->SetMarkerColor(9102);
+	get_TProfile("TJjet_pullEseen_vs_Etrue_bjets")->SetMarkerSize(2);
+	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets")->SetLineColor(9103);
+	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets")->SetMarkerColor(9103);
+	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets")->SetMarkerSize(2);
+	get_TProfile("TJjet_pullEseen_vs_Etrue_bjets")->Draw();
+	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets")->Draw("same");
+	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets")->Draw("same");
+	leg_jetEpull_bjets->AddEntry(get_TProfile("TJjet_pullEseen_vs_Etrue_bjets"), "uncorrected");
+	leg_jetEpull_bjets->AddEntry(get_TProfile("TJjet_pullEseencorrected_vs_Etrue_bjets"), "corrected");
+	leg_jetEpull_bjets->AddEntry(get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_bjets"), "with MC #nu");
+	leg_jetEpull_bjets->Draw();
+	gPad->Update();
+	TLine* pull_line_bjets = new TLine(0, 0, gPad->GetFrame()->GetX2(), 0);
+	pull_line_bjets->SetLineWidth(1);
+	pull_line_bjets->Draw("same");
+	c_jetEpull_bjets->SetTopMargin(0.1);
+	c_jetEpull_bjets->Print((output_dir + "/jetEpull_comparison_bjets.pdf").c_str());
+
+
+
 	TCanvas* c_jetE_semilepbjets = new TCanvas("c_jetE_semilepbjets", "", 0, 0, 800, 800);
-	TLegend* leg_jetE_semilepbjets = new TLegend(0.25, 0.7, 0.55, 0.85);
+	TLegend* leg_jetE_semilepbjets = new TLegend(0.2, 0.62, 0.55, 0.85);
 	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_semilepbjets")->SetLineColor(9101);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_semilepbjets")->SetMarkerColor(9101);
+	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_semilepbjets")->SetMarkerSize(2);
 	get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets")->SetLineColor(9102);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets")->SetMarkerColor(9102);
+	get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets")->SetMarkerSize(2);
 	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_semilepbjets")->SetLineColor(9103);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_semilepbjets")->SetMarkerColor(9103);
+	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_semilepbjets")->SetMarkerSize(2);
 	get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets")->SetMinimum(0);
 	get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets")->Draw();
 	get_TProfile("TJjet_meanEseencorrected_vs_Etrue_semilepbjets")->Draw("same");
 	get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_semilepbjets")->Draw("same");
-	leg_jetE_semilepbjets->AddEntry(get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets"), "uncorrected", "l");
-	leg_jetE_semilepbjets->AddEntry(get_TProfile("TJjet_meanEseencorrected_vs_Etrue_semilepbjets"), "corrected", "l");
-	leg_jetE_semilepbjets->AddEntry(get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_semilepbjets"), "with MC #nu", "l");
+	leg_jetE_semilepbjets->AddEntry(get_TProfile("TJjet_meanEseen_vs_Etrue_semilepbjets"), "uncorrected");
+	leg_jetE_semilepbjets->AddEntry(get_TProfile("TJjet_meanEseencorrected_vs_Etrue_semilepbjets"), "corrected");
+	leg_jetE_semilepbjets->AddEntry(get_TProfile("TJjet_meanEseencorrectedwithMC_vs_Etrue_semilepbjets"), "with MC #nu");
 	leg_jetE_semilepbjets->Draw();
 	gPad->Update();
 	TLine* profile_line_semilepbjets = new TLine(0, 0, gPad->GetFrame()->GetY2(), gPad->GetFrame()->GetY2());
@@ -292,18 +319,24 @@ void RoughNuCorrectionOnTJjetsPlotter::draw_plots(){
 
 
 	TCanvas* c_jetEpull_semilepbjets = new TCanvas("c_jetEpull_semilepbjets", "", 0, 0, 800, 800);
-	TLegend* leg_jetEpull_semilepbjets = new TLegend(0.25, 0.3, 0.5, 0.45);
+	TLegend* leg_jetEpull_semilepbjets = new TLegend(0.2, 0.2, 0.5, 0.45);
 	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_semilepbjets")->SetLineColor(9101);
+	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_semilepbjets")->SetMarkerColor(9101);
+	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_semilepbjets")->SetMarkerSize(2);
 	get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets")->SetLineColor(9102);
+	get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets")->SetMarkerColor(9102);
+	get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets")->SetMarkerSize(2);
 	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_semilepbjets")->SetLineColor(9103);
+	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_semilepbjets")->SetMarkerColor(9103);
+	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_semilepbjets")->SetMarkerSize(2);
 	// get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets")->SetMinimum(-44);
 	// get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets")->SetMaximum(16);
 	get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets")->Draw();
 	get_TProfile("TJjet_pullEseencorrected_vs_Etrue_semilepbjets")->Draw("same");
 	get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_semilepbjets")->Draw("same");
-	leg_jetEpull_semilepbjets->AddEntry(get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets"), "uncorrected", "l");
-	leg_jetEpull_semilepbjets->AddEntry(get_TProfile("TJjet_pullEseencorrected_vs_Etrue_semilepbjets"), "corrected", "l");
-	leg_jetEpull_semilepbjets->AddEntry(get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_semilepbjets"), "with MC #nu", "l");
+	leg_jetEpull_semilepbjets->AddEntry(get_TProfile("TJjet_pullEseen_vs_Etrue_semilepbjets"), "uncorrected");
+	leg_jetEpull_semilepbjets->AddEntry(get_TProfile("TJjet_pullEseencorrected_vs_Etrue_semilepbjets"), "corrected");
+	leg_jetEpull_semilepbjets->AddEntry(get_TProfile("TJjet_pullEseencorrectedwithMC_vs_Etrue_semilepbjets"), "with MC #nu");
 	leg_jetEpull_semilepbjets->Draw();
 	gPad->Update();
 	TLine* pull_line_semilepbjets = new TLine(0, 0, gPad->GetFrame()->GetX2(), 0);

--- a/plotting/plotters/src/nu_rough_correction_proof_of_principle.cpp
+++ b/plotting/plotters/src/nu_rough_correction_proof_of_principle.cpp
@@ -120,21 +120,21 @@ void RoughNuCorrectionPOPPlotter::fill_plots(){
 			float E_lep = (get_charged_leptons_tlv(vertex)).E();
 			double nu_E = nu_energy_correction( E_lep );
 
-			get_TH2D("nu_E")->Fill(nu_tlv_true.E(), nu_E, weight);
+			get_TH2D("nu_E")->Fill(nu_tlv_true.E(), nu_E, 1);
 
 			if ( is_Cmeson_ID(first_parent_pdg) || is_Bmeson_ID(first_parent_pdg) ) {
-				get_TH2D("nu_E_CandBparents_only")->Fill(nu_tlv_true.E(), nu_E, weight);
-				get_TProfile("nu_E_profile_CandBparents_only")->Fill(nu_tlv_true.E(), nu_E, weight);
-				get_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only")->Fill(E_lep, (nu_E - nu_tlv_true.E()), weight);
+				get_TH2D("nu_E_CandBparents_only")->Fill(nu_tlv_true.E(), nu_E, 1);
+				get_TProfile("nu_E_profile_CandBparents_only")->Fill(nu_tlv_true.E(), nu_E, 1);
+				get_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only")->Fill(E_lep, (nu_E - nu_tlv_true.E()), 1);
 				float parent_init_pos = ((Particle*)(vertex->vertex_parents[0]))->MC.vertex.Mag(); // TODO Adjust to non-zero init vertex
 				if ( parent_init_pos == 0.0 ) {
-					get_TH2D("nu_E_CandBparents_only_0vertex")->Fill(nu_tlv_true.E(), nu_E, weight);
+					get_TH2D("nu_E_CandBparents_only_0vertex")->Fill(nu_tlv_true.E(), nu_E, 1);
 					if ( vis_E > 5.0) {
-						get_TH2D("nu_E_CandBparents_only_0vertex_visEgr5")->Fill(nu_tlv_true.E(), nu_E, weight);
+						get_TH2D("nu_E_CandBparents_only_0vertex_visEgr5")->Fill(nu_tlv_true.E(), nu_E, 1);
 					}
 
 					if ( E_lep > 5.0) {
-						get_TH2D("nu_E_CandBparents_only_0vertex_lepEgr5")->Fill(nu_tlv_true.E(), nu_E, weight);
+						get_TH2D("nu_E_CandBparents_only_0vertex_lepEgr5")->Fill(nu_tlv_true.E(), nu_E, 1);
 					}
 				}
 			}

--- a/plotting/plotters/src/nu_rough_correction_proof_of_principle.cpp
+++ b/plotting/plotters/src/nu_rough_correction_proof_of_principle.cpp
@@ -12,9 +12,14 @@ void RoughNuCorrectionPOPPlotter::define_plots(){
 	add_new_TH2D("nu_E_CandBparents_only_0vertex_visEgr5", new TH2D("nu_E_CandBparents_only_0vertex_visEgr5", "E_{#nu}^{calc from MC lep} : E_{#nu}^{lep}, C and B parents starting at 0, E_{vis}>5; E_{#nu}^{MC} [GeV]; E_{#nu}^{calc} [GeV]; #nu's", 110, 0, 110, 110, 0, 110) );
 	add_new_TH2D("nu_E_CandBparents_only_0vertex_lepEgr5", new TH2D("nu_E_CandBparents_only_0vertex_lepEgr5", "E_{#nu}^{calc from MC lep} : E_{#nu}^{lep}, C and B parents starting at 0, E_{lep}>5; E_{#nu}^{MC} [GeV]; E_{#nu}^{calc} [GeV]; #nu's", 110, 0, 110, 110, 0, 110) );
 
-	add_new_TProfile("nu_E_profile_CandBparents_only", new TProfile("nu_E_profile_CandBparents_only", "<E_{#nu}^{calc from MC lep}> : E_{#nu}^{lep}, C and B parents; E_{#nu}^{MC} [GeV], C and B parents; E_{#nu}^{calc} [GeV]; #nu's", 7, 0, 140) );
+	const int N_profile_bins = 12;
+	double profile_binning[N_profile_bins+1] = {0, 1, 2, 3, 5, 7, 10, 15, 20, 30, 50, 70, 100};
 
-	add_new_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only", new TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only", "<E_{#nu}^{calc from MC lep} - E_{#nu}^{MC}> : E_{lep}, C and B parents; E_{lep}; <E_{#nu}^{calc from MC lep} - E_{#nu}^{MC}>", 7, 0, 140));
+	add_new_TProfile("nu_E_profile_CandBparents_only", new TProfile("nu_E_profile_CandBparents_only", "<E_{#nu}^{calc from MC lep}> : E_{#nu}^{lep}, C and B parents; E_{#nu}^{MC} [GeV], C and B parents; E_{#nu}^{calc} [GeV]; #nu's", N_profile_bins, profile_binning) );
+	add_new_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only", new TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only", "<E_{#nu}^{calc from MC lep} - E_{#nu}^{MC}> : E_{lep}, C and B parents; E_{lep}; <E_{#nu}^{calc from MC lep} - E_{#nu}^{MC}>", N_profile_bins, profile_binning));
+
+	get_TProfile("nu_E_profile_CandBparents_only")->SetErrorOption("s");
+	get_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only")->SetErrorOption("s");
 }
 
 bool RoughNuCorrectionPOPPlotter::isNeutrinoID( int pdgID ) {
@@ -75,14 +80,14 @@ bool  RoughNuCorrectionPOPPlotter::is_Cmeson_ID( int pdgID ) {
 }
 
 double RoughNuCorrectionPOPPlotter::fitted_mean_x( double E_lep ){
-	double a = 0.88;
-	double b = 10.6;
+	double a = 0.72;
+	double b = 1.96;
 	return a*E_lep / ( b + E_lep );
 }
 
 double RoughNuCorrectionPOPPlotter::fitted_delta_mean_x( double E_lep ){
-	double a = 0.017;
-	double b = 0.00057;
+	double a = 0.243;
+	double b = -0.00105;
 	return a + b*E_lep;
 }
 
@@ -145,9 +150,11 @@ void RoughNuCorrectionPOPPlotter::fill_plots(){
 void RoughNuCorrectionPOPPlotter::draw_plots(){
 	std::string output_dir = get_output_directory();
 
+	const int N_profile_bins = 12;
+
 	TGraph* pull_error_estimate = new TGraph(14);
 	//double E_lep_array[5], pull_plus_delta_array[5], pull_minus_delta_array[5];
-	for (int i=0; i<7; i++) {
+	for (int i=0; i<N_profile_bins; i++) {
 		double E_lep = get_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only")->GetBinCenter(i+1);
 		double pull = get_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only")->GetBinContent(i+1);
 		double delta_estimation = nu_energy_error_estimate(E_lep);
@@ -167,7 +174,9 @@ void RoughNuCorrectionPOPPlotter::draw_plots(){
 	get_TProfile("nu_E_correction_pull_VS_Elep_CandBparents_only")->Draw();
 	pull_error_estimate->Draw("same *");
 	leg_pull_profile->AddEntry(pull_error_estimate, "error estimate", "p");
-	leg_pull_profile->Draw();
+	leg_pull_profile->Draw("same");
+	TLine* pull_profile_line = new TLine(0, 0, 100, 0);
+	pull_profile_line->Draw("same");
 	c_pull_profile->SetTopMargin(0.1);
 	c_pull_profile->Print((output_dir + "/pull_profile.pdf").c_str());
 

--- a/plotting/src/configuration.cpp
+++ b/plotting/src/configuration.cpp
@@ -9,10 +9,10 @@ void set_plotters(std::vector<Plotter*> &plotters) {
 	//plotters.push_back( new TestPlotter );
 	plotters.push_back( new LepNuPairPlotter);
 	//plotters.push_back( new CheatedCorrectionPlotter );
-	//plotters.push_back( new NuCalculationPOPPlotter );
-	//plotters.push_back( new NuCalculationCheatedSignPOPPlotter );
-	//plotters.push_back( new NuCalculationPOPGuessedGammaPlotter );
-	//plotters.push_back( new CheatedNuCalculationReco4MomentaPlotter );
+	// plotters.push_back( new NuCalculationPOPPlotter );
+	// plotters.push_back( new NuCalculationCheatedSignPOPPlotter );
+	// plotters.push_back( new NuCalculationPOPGuessedGammaPlotter );
+	// plotters.push_back( new CheatedNuCalculationReco4MomentaPlotter );
 	plotters.push_back( new RoughNuCorrectionFitPlotter );
 	plotters.push_back( new RoughNuCorrectionPOPPlotter );
 	plotters.push_back( new RoughNuCorrectionOnTJjetsPlotter );


### PR DESCRIPTION
Corrected some problems with the average neutrino correction:
- Lep-nu vertex weights are now 1.
- The binning is now finer in the low-E region to account for higher
statistics. 
- In the error estimation the estimator was changed from "std
dev of mean" to "std dev of distribution" ( = Need to account for shape
uncertainty and not for low statistics in my MC).